### PR TITLE
Change document title for sidebar clarity.

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
 name: efcore-provider
 version: '1.0'
-title: Couchbase Entity Framework Core Provider
+title: .NET Entity Framework
 start_page: ROOT:overview.adoc
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
The title of the doc would look better if we make it a bit more concise. This change makes it clear that it's .NET, and elides the "Core Provider" since that'll be pretty obvious since it's database docs.