### PR TITLE
Removing using statement from getting started

### DIFF
--- a/modules/ROOT/pages/start-using-efcore-provider.adoc
+++ b/modules/ROOT/pages/start-using-efcore-provider.adoc
@@ -94,7 +94,7 @@ public class BloggingContext : DbContext
     
     protected override void OnConfiguring(DbContextOptionsBuilder options)
     {
-        using var loggingFactory = LoggerFactory.Create(builder => builder.AddConsole());
+        var loggingFactory = LoggerFactory.Create(builder => builder.AddConsole());
         options.UseCouchbase(
             new ClusterOptions()
                 .WithCredentials("USERNAME", "PASSWORD")


### PR DESCRIPTION
The using statement was causing a bug as the LoggerFactory was being disposed unintentionally.